### PR TITLE
Add dbus method cold_reset() for bmc dbus object

### DIFF
--- a/dbus-interfaces.md
+++ b/dbus-interfaces.md
@@ -151,4 +151,11 @@ properties:
 
   *  `state`
 
+# BMC
+
+## `/org/openbmc/control/bmc/bmc0`
+
+methods:
+
+  *  `cold_reset()`
 


### PR DESCRIPTION
This method will cold reset BMC itself.