### PR TITLE
cheatsheet: Fix misspelling of TEMPLATECONF

### DIFF
--- a/cheatsheet.md
+++ b/cheatsheet.md
@@ -50,7 +50,7 @@ You can reconfigure your build by removing the build/conf dir:
 ```
 rm -rf build/conf
 ```
-and running `oe-init-build-env` again (possibly with `TEMPLATE_CONF` set).
+and running `oe-init-build-env` again (possibly with `TEMPLATECONF` set).
 
 ## Useful dbus CLI tools
 


### PR DESCRIPTION
The existing hint would not work, as the tool expects the variable to be
called TEMPLATECONF not TEMPLATE_CONF.

Signed-off-by: Joel Stanley <joel@jms.id.au>