### PR TITLE
dbus-interface-doc: Add PowerCap and OccStatus description

### DIFF
--- a/dbus-interfaces.md
+++ b/dbus-interfaces.md
@@ -87,6 +87,12 @@ properties:
 
   *  `worst_threshold_state`
 
+### `/org/openbmc/sensors/host/PowerCap`
+This object is used to set Host PowerCap. In turn a OCC "Set User PowerCap" command is sent to OCC.
+
+### `/org/openbmc/sensors/host/OccStatus`
+This object can set OCC state to either: "Enabled" or "Disabled".
+
 # Inventory
 
 ## `/org/openbmc/inventory/<item hierarchy>`


### PR DESCRIPTION
Add description for dbus objects '/org/openbmc/sensors/host/PowerCap'
and '/org/openbmc/sensors/host/OccStatus'.

Signed-off-by: Yi Li <adamliyi@msn.com>