### PR TITLE
userguide: Generate userguide.tex to include \tightlist macro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,11 @@ all: userguide.pdf
 
 .PHONY: all clean
 
-userguide.pdf: userguide/userguide.tex
+userguide.pdf: userguide.tex
 	$(tex) $^
+
+userguide.tex: userguide/userguide.tex
+	pandoc -f latex -t latex -s -o $@ $^
 
 userguide/userguide.tex: rest-api.tex host-management.tex console.tex code-update.tex
 

--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,4 @@ userguide/userguide.tex: rest-api.tex host-management.tex console.tex code-updat
 	pandoc -o $@ $^
 
 clean:
-	rm -f *.aux *.tex *.out *.pdf
+	rm -f *.tex userguide.*


### PR DESCRIPTION
Allow xelatex to build userguide.pdf without errors.

pandoc injects \tightlist macros into its output files which cause
xelatex to choke. By processing the hand-rolled userguide.tex with
pandoc the definition is injected and xelatex can build the PDF.

Signed-off-by: Andrew Jeffery <andrew@aj.id.au>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/docs/23)
<!-- Reviewable:end -->
