### PR TITLE
dbus-interfaces: Add org.openbmc.control.BmcFlash.update method

### DIFF
--- a/dbus-interfaces.md
+++ b/dbus-interfaces.md
@@ -311,6 +311,8 @@ The control.BmcFlash interface allows applications update the BMC firmware.
 | `updateViaTftp` | `ss`         | `void`        | **Perform a BMC firmware update using a TFTP server.**|
 |                 | `s`          |               | The ipv4 address of the TFTP server hosting the firmware image file.|
 |                 | `s`          |               | The name of the file containing the BMC firmware image.|
+| `update`        | `s`          | `void`        | **Perform a BMC firmware update with a file already on the BMC.**|
+|                 | `s`          |               | The name of the file containing the BMC firmware image.|
 
 ### signals
 | name           | signature | description                              |


### PR DESCRIPTION
I created the pull request for skeleton, now I am making sure the documentation reflects the change too.  Basically it allows someone to copy a bmc image on to the server to flash it.  This removes the requirement for a tftp server to be used

https://github.com/openbmc/skeleton/pull/87

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/docs/26)
<!-- Reviewable:end -->
