### PR TITLE
Document updated bmc flash interface and procedure

### DIFF
--- a/dbus-interfaces.md
+++ b/dbus-interfaces.md
@@ -306,13 +306,18 @@ notifications.
 The control.BmcFlash interface allows applications update the BMC firmware.
 
 ### methods
-| name            | in signature | out signature | description                 |
-| --------------- | ------------ | ------------- | --------------------------- |
-| `updateViaTftp` | `ss`         | `void`        | **Perform a BMC firmware update using a TFTP server.**|
-|                 | `s`          |               | The ipv4 address of the TFTP server hosting the firmware image file.|
-|                 | `s`          |               | The name of the file containing the BMC firmware image.|
-| `update`        | `s`          | `void`        | **Perform a BMC firmware update with a file already on the BMC.**|
-|                 | `s`          |               | The name of the file containing the BMC firmware image.|
+| name                | in signature | out signature | description                 |
+| ------------------- | ------------ | ------------- | --------------------------- |
+| `updateViaTftp`     | `ss`         | `void`        | **Perform a BMC firmware update using a TFTP server.**|
+|                     | `s`          |               | The ipv4 address of the TFTP server hosting the firmware image file.|
+|                     | `s`          |               | The name of the file containing the BMC firmware image.|
+| `update`            | `s`          | `void`        | **Perform a BMC firmware update with a file already on the BMC.**|
+|                     | `s`          |               | The name of the file containing the BMC firmware image.|
+| `PrepareForUpdate`  | `void`       | `void`        | **Reboot BMC with Flash content cached in RAM **|
+| `Abort`             | `void`       | `void`        | **Abort any pending, broken, or in-progress flash update**|
+| `Apply`             | `void`       | `void`        | **Initiate writing image into flash**|
+| `GetUpdateProgress` | `void`       | `s`           | **Display progress log `Apply` phase**|
+|                     |              | `s`           | The `state` and log output from `Apply` |
 
 ### signals
 | name           | signature | description                              |
@@ -324,12 +329,13 @@ The control.BmcFlash interface allows applications update the BMC firmware.
 ### properties
 | name                           | signature | description                     |
 | ------------------------------ | --------- | ------------------------------- |
-| `status`                       | `s`       | **?**                           |
+| `status`                       | `s`       | **Description of the phase of the update**        |
 | `filename`                     | `s`       | **The name of the file containing the BMC firmware image.**|
 | `preserve_network_settings`    | `b`       | **Perform a factory reset.**    |
-| `restore_application_defaults` | `b`       | **Perform a factory reset.**    |
-| `update_kernel_and_apps`       | `b`       | **Perform a factory reset.**    |
-| `clear_persistent_files`       | `b`       | **Perform a factory reset.**    |
+| `restore_application_defaults` | `b`       | **Clear modified files in read-write filesystem.**    |
+| `update_kernel_and_apps`       | `b`       | **Do not update bootloader (requires image pieces).**    |
+| `clear_persistent_files`       | `b`       | **Also remove persistent files when updating read-write filesystem.**    |
+| `auto_apply`                   | `b`       | **Attempt to apply image after unpacking (cleared if image verification fails)**    |
 
 ### namespace
 | path                             | required | description |

--- a/dbus-interfaces.md
+++ b/dbus-interfaces.md
@@ -311,6 +311,8 @@ The control.BmcFlash interface allows applications update the BMC firmware.
 | `updateViaTftp` | `ss`         | `void`        | **Perform a BMC firmware update using a TFTP server.**|
 |                 | `s`          |               | The ipv4 address of the TFTP server hosting the firmware image file.|
 |                 | `s`          |               | The name of the file containing the BMC firmware image.|
+| `update`        | `s`          | `void`        | **Perform a BMC firmware update with a file already on the BMC.**|
+|                 | `s`          |               | The name of the file containing the BMC firmware image.|
 
 ### signals
 | name           | signature | description                              |


### PR DESCRIPTION
 Document BMC flash update enhancements

The BMC flash update process was enhanced to allow the images to be
written to flash while the system is operational allowing progress
to be mointored.

Update the documentation describing how to use the new interfaces.
Also add or update the description of the prior interface.

Fixes: openbmc/openbmc#293
Signed-off-by: Milton Miller <miltonm@us.ibm.com>

---
I did not have a chance to test the added commands.  
I based on @causten #26 and can rebase if necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/docs/31)
<!-- Reviewable:end -->
