### PR TITLE
Host poweroff: Removed extra slash on URL

### DIFF
--- a/REST-cheatsheet.md
+++ b/REST-cheatsheet.md
@@ -71,7 +71,7 @@ Note: To keep the syntax below common between the phosphor-rest and bmcweb
 
 * Host hard power off:
    ```
-   $ curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/json" -X PUT -d '{"data":"xyz.openbmc_project.State.Chassis.Transition.Off"}' https://${bmc}//xyz/openbmc_project/state/chassis0/attr/RequestedPowerTransition
+   $ curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/json" -X PUT -d '{"data":"xyz.openbmc_project.State.Chassis.Transition.Off"}' https://${bmc}/xyz/openbmc_project/state/chassis0/attr/RequestedPowerTransition
    ```
 
 * Host power on:

--- a/host-management.md
+++ b/host-management.md
@@ -214,7 +214,7 @@ $ curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/json" -d '{"da
 To issue a hard power off (accomplished by powering off the chassis):
 
 ```
-$ curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/json" -X PUT -d '{"data":"xyz.openbmc_project.State.Chassis.Transition.Off"}' https://${bmc}//xyz/openbmc_project/state/chassis0/attr/RequestedPowerTransition
+$ curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/json" -X PUT -d '{"data":"xyz.openbmc_project.State.Chassis.Transition.Off"}' https://${bmc}/xyz/openbmc_project/state/chassis0/attr/RequestedPowerTransition
 ```
 
 To reboot the host:
@@ -265,6 +265,7 @@ state, for example, attempting to reboot the system.
 The host watchdog utilizes the generic [phosphor-watchdog][1] repository. The
 host watchdog service provides 2 files as configuration options into
 phosphor-watchdog:
+
 
     /lib/systemd/system/phosphor-watchdog@poweron.service.d/poweron.conf
     /etc/default/obmc/watchdog/poweron

--- a/host-management.md
+++ b/host-management.md
@@ -266,7 +266,6 @@ The host watchdog utilizes the generic [phosphor-watchdog][1] repository. The
 host watchdog service provides 2 files as configuration options into
 phosphor-watchdog:
 
-
     /lib/systemd/system/phosphor-watchdog@poweron.service.d/poweron.conf
     /etc/default/obmc/watchdog/poweron
 


### PR DESCRIPTION
While @JPalacios14 and I were trying some of the examples, specifically the "Host hard power off" curl example, we kept getting a "Not Found" error. This was due to the fact that there was two "//" after "${bmc}" i.e. `https://${bmc}//xyz/openbmc_project/state/chassis0/attr/RequestedPowerTransition`. This change removes the extra '/' and we are able to get an OK status response. 