### PR TITLE
Suggest to run `ldd` before running `qemu-system-arm`

### DIFF
--- a/development/dev-environment.md
+++ b/development/dev-environment.md
@@ -119,6 +119,8 @@ relative to your current directory.
    cp ./tmp/deploy/images/romulus/obmc-phosphor-image-romulus.static.mtd ./
    ```
 
+   **Note** - You may want to run `ldd ./qemu-system-arm | grep "not found"` to see if there are any missing dependencies of `qemu-system-arm`.
+
 3. Start QEMU with the Romulus image
 
    **Note** - For REST, SSH and IPMI to work into your QEMU session, you must


### PR DESCRIPTION
During my practices, I noticed that both on my VMWare guest Ubuntu Linux and on my Google Cloud Ubuntu Linux there are three missing libraries needed by `qemu-system-arm`. I fixed it by running `ldd ./qemu-system-arm | grep "not found"` and then run `sudo apt install`.